### PR TITLE
Add iprocess infrastructure for development, training1 & training2

### DIFF
--- a/groups/iprocess-infrastructure/asg.tf
+++ b/groups/iprocess-infrastructure/asg.tf
@@ -1,0 +1,153 @@
+# ------------------------------------------------------------------------------
+# CHIPS Security Group and rules
+# ------------------------------------------------------------------------------
+module "asg_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.3"
+
+  name        = "sgr-${var.application}-asg-001"
+  description = "Security group for the ${var.application} asg"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_rules       = ["ssh-tcp"]
+  ingress_prefix_list_ids  = [data.aws_ec2_managed_prefix_list.administration.id]
+
+  egress_rules = ["all-all"]
+}
+
+resource "aws_security_group_rule" "rpc_from_tibco_client" {
+  description       = "Client inbound rpc port"
+  from_port         = 111
+  to_port           = 111
+  protocol          = "tcp"
+  type              = "ingress"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.administration.id]
+  security_group_id = module.asg_security_group.security_group_id
+}
+
+resource "aws_security_group_rule" "connection_from_tibco_client" {
+  description       = "Client inbound connection port range"
+  from_port         = 31000
+  to_port           = 31049
+  protocol          = "tcp"
+  type              = "ingress"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.administration.id]
+  security_group_id = module.asg_security_group.security_group_id
+}
+
+resource "aws_security_group_rule" "spo_from_onprem_weblogic" {
+  description       = "On-premise WebLogic inbound port range"
+  from_port         = 30511
+  to_port           = 30514
+  protocol          = "tcp"
+  type              = "ingress"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.administration.id]
+  security_group_id = module.asg_security_group.security_group_id
+}
+
+resource "aws_security_group_rule" "spo_from_cloud_weblogic" {
+  description              = "Oracle DB inbound port range"
+  from_port                = 30511
+  to_port                  = 30514
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = data.aws_security_group.chips_devtest_app.id
+  security_group_id        = module.asg_security_group.security_group_id
+}
+
+resource "aws_security_group_rule" "db_events_from_rds" {
+  description              = "Oracle DB inbound port range"
+  from_port                = 30001
+  to_port                  = 30100
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = data.aws_security_group.iprocess_rds.id
+  security_group_id        = module.asg_security_group.security_group_id
+}
+
+# ASG Module
+module "asg" {
+  source = "./autoscaling-with-launch-template"
+
+  count = var.asg_count
+
+  name = format("%s-%s", var.application, var.environment)
+
+  # Launch template configuration
+  lt_name       = format("%s-%s-%s-launchtemplate", var.application, var.environment, count.index)
+  image_id      = data.aws_ami.iprocess_app.id
+  instance_type = var.instance_size
+  core_count    = 2
+  security_groups = [
+    module.asg_security_group.security_group_id
+  ]
+  root_block_device = [
+    {
+      volume_size = var.instance_root_volume_size
+      volume_type = "gp2"
+      encrypted   = true
+      iops        = 0
+    }
+  ]
+
+  # Auto scaling group
+  asg_name                       = format("%s-%s-%s-asg", var.application, var.environment, count.index)
+  vpc_zone_identifier            = data.aws_subnet_ids.application.ids
+  health_check_type              = "EC2"
+  min_size                       = var.asg_min_size
+  max_size                       = var.asg_max_size
+  desired_capacity               = var.asg_desired_capacity
+  health_check_grace_period      = 300
+  wait_for_capacity_timeout      = 0
+  force_delete                   = true
+  enable_instance_refresh        = var.enable_instance_refresh
+  refresh_min_healthy_percentage = 50
+  key_name                       = aws_key_pair.iprocess_app_keypair.key_name
+  
+  iam_instance_profile = module.instance_profile.aws_iam_instance_profile.name
+  user_data_base64     = data.template_cloudinit_config.userdata_config.rendered
+
+  tags_as_map = local.default_tags
+}
+
+resource "aws_cloudwatch_log_group" "log_groups" {
+  for_each = local.cloudwatch_instance_logs
+
+  name              = each.value["log_group_name"]
+  retention_in_days = lookup(each.value, "log_group_retention", var.default_log_group_retention_in_days)
+  kms_key_id        = lookup(each.value, "kms_key_id", local.logs_kms_key_id)
+}
+
+#--------------------------------------------
+# ASG CloudWatch Alarms
+#--------------------------------------------
+module "asg_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/asg-cloudwatch-alarms?ref=tags/1.0.116"
+
+  count = var.asg_count
+
+  autoscaling_group_name = module.asg[count.index].this_autoscaling_group_name
+  prefix                 = "${var.aws_account}-${var.application}-${count.index}-asg-alarms"
+
+  in_service_evaluation_periods      = "1"
+  in_service_statistic_period        = "60"
+  expected_instances_in_service      = 1
+  in_pending_evaluation_periods      = "3"
+  in_pending_statistic_period        = "120"
+  in_standby_evaluation_periods      = "3"
+  in_standby_statistic_period        = "120"
+  in_terminating_evaluation_periods  = "3"
+  in_terminating_statistic_period    = "120"
+  total_instances_evaluation_periods = "1"
+  total_instances_statistic_period   = "120"
+  total_instances_in_service         = 1
+
+  actions_alarm = var.enable_sns_topic ? [module.cloudwatch_sns_email[0].sns_topic_arn, module.cloudwatch_sns_ooh[0].sns_topic_arn] : []
+  actions_ok    = var.enable_sns_topic ? [module.cloudwatch_sns_email[0].sns_topic_arn, module.cloudwatch_sns_ooh[0].sns_topic_arn] : []
+
+
+  depends_on = [
+    module.cloudwatch_sns_email,
+    module.asg
+  ]
+}

--- a/groups/iprocess-infrastructure/asg.tf
+++ b/groups/iprocess-infrastructure/asg.tf
@@ -67,7 +67,7 @@ resource "aws_security_group_rule" "db_events_from_rds" {
 
 # ASG Module
 module "asg" {
-  source = "./autoscaling-with-launch-template"
+  source = "git@github.com:companieshouse/terraform-modules//aws/autoscaling-with-launch-template?ref=tags/1.0.184"
 
   count = var.asg_count
 

--- a/groups/iprocess-infrastructure/asg.tf
+++ b/groups/iprocess-infrastructure/asg.tf
@@ -77,7 +77,6 @@ module "asg" {
   lt_name       = format("%s-%s-%s-launchtemplate", var.application, var.environment, count.index)
   image_id      = data.aws_ami.iprocess_app.id
   instance_type = var.instance_size
-  core_count    = 2
   security_groups = [
     module.asg_security_group.security_group_id
   ]

--- a/groups/iprocess-infrastructure/data.tf
+++ b/groups/iprocess-infrastructure/data.tf
@@ -57,10 +57,6 @@ data "vault_generic_secret" "security_s3_buckets" {
   path = "aws-accounts/security/s3"
 }
 
-data "vault_generic_secret" "chs_vpc_subnets" {
-  path = "aws-accounts/${var.environment}/vpc/subnets"
-}
-
 data "vault_generic_secret" "iprocess_app_ec2_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/app/ec2"
 }

--- a/groups/iprocess-infrastructure/data.tf
+++ b/groups/iprocess-infrastructure/data.tf
@@ -1,0 +1,113 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "vpc" {
+  tags = {
+    Name = "vpc-${var.aws_account}"
+  }
+}
+
+data "aws_subnet_ids" "application" {
+  vpc_id = data.aws_vpc.vpc.id
+  filter {
+    name   = "tag:Name"
+    values = ["sub-application-*"]
+  }
+}
+
+data "aws_security_group" "chips_devtest_app" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-devtest-asg-001-*"]
+  }
+}
+
+data "aws_security_group" "iprocess_rds" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-staffware-${var.environment}-rds-001-*"]
+  }
+}
+
+data "aws_route53_zone" "private_zone" {
+  name         = local.internal_fqdn
+  private_zone = true
+}
+
+data "aws_ec2_managed_prefix_list" "administration" {
+  name = "administration-cidr-ranges"
+}
+
+data "vault_generic_secret" "account_ids" {
+  path = "aws-accounts/account-ids"
+}
+
+data "vault_generic_secret" "s3_releases" {
+  path = "aws-accounts/shared-services/s3"
+}
+
+data "vault_generic_secret" "kms_keys" {
+  path = "aws-accounts/${var.aws_account}/kms"
+}
+
+data "vault_generic_secret" "security_kms_keys" {
+  path = "aws-accounts/security/kms"
+}
+
+data "vault_generic_secret" "security_s3_buckets" {
+  path = "aws-accounts/security/s3"
+}
+
+data "vault_generic_secret" "chs_vpc_subnets" {
+  path = "aws-accounts/${var.environment}/vpc/subnets"
+}
+
+data "vault_generic_secret" "iprocess_app_ec2_data" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/app/ec2"
+}
+
+data "vault_generic_secret" "iprocess_app_config_data" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}-${var.environment}/app/iprocess"
+}
+
+# ------------------------------------------------------------------------------
+# iProcess App data
+# ------------------------------------------------------------------------------
+data "aws_ami" "iprocess_app" {
+  owners      = [data.vault_generic_secret.account_ids.data["development"]]
+  most_recent = var.ami_name == "iprocess-app-*" ? true : false
+
+  filter {
+    name = "name"
+    values = [
+      var.ami_name,
+    ]
+  }
+
+  filter {
+    name = "state"
+    values = [
+      "available",
+    ]
+  }
+}
+
+data "template_file" "userdata" {
+  template = file("${path.module}/templates/user_data.tpl")
+
+  vars = {
+    R53_ZONEID                = data.aws_route53_zone.private_zone.zone_id
+    IPROCESS_APP_INPUTS       = jsonencode(local.iprocess_app_deployment_ansible_inputs)
+    IPROCESS_TNS_INPUTS       = jsonencode(local.iprocess_tnsnames_inputs)
+    IPROCESS_STAFF_DAT_INPUTS = jsonencode(local.iprocess_staff_dat_inputs)
+  }
+}
+
+data "template_cloudinit_config" "userdata_config" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = data.template_file.userdata.rendered
+  }
+}

--- a/groups/iprocess-infrastructure/iam.tf
+++ b/groups/iprocess-infrastructure/iam.tf
@@ -1,0 +1,53 @@
+module "instance_profile" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.59"
+
+  name       = format("%s-%s-profile", var.application, var.environment)
+  enable_SSM = true
+
+  s3_buckets_write = [local.session_manager_bucket_name]
+
+  kms_key_refs = [
+    "alias/${var.account}/${var.region}/ebs",
+    local.ssm_kms_key_id
+  ]
+
+  cw_log_group_arns = length(local.log_groups) > 0 ? [format(
+    "arn:aws:logs:%s:%s:log-group:%s-*:*",
+    var.aws_region,
+    data.aws_caller_identity.current.account_id,
+    var.application
+  )] : null
+
+  custom_statements = [
+    {
+      sid    = "AllowAccessToReleaseBucket",
+      effect = "Allow",
+      resources = [
+        "arn:aws:s3:::shared-services.eu-west-2.releases.ch.gov.uk/*",
+        "arn:aws:s3:::shared-services.eu-west-2.releases.ch.gov.uk",
+        "arn:aws:s3:::shared-services.eu-west-2.configs.ch.gov.uk/*",
+        "arn:aws:s3:::shared-services.eu-west-2.configs.ch.gov.uk"
+      ],
+      actions = [
+        "s3:Get*",
+        "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowWriteToRoute53",
+      effect    = "Allow",
+      resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.private_zone.zone_id}"],
+      actions = [
+        "route53:ChangeResourceRecordSets"
+      ]
+    },
+    {
+      sid       = "CloudwatchMetrics"
+      effect    = "Allow"
+      resources = ["*"]
+      actions = [
+        "cloudwatch:PutMetricData"
+      ]
+    }
+  ]
+}

--- a/groups/iprocess-infrastructure/keys.tf
+++ b/groups/iprocess-infrastructure/keys.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "iprocess_app_keypair" {
+  key_name   = var.application
+  public_key = local.iprocess_app_ec2_data["public-key"]
+}

--- a/groups/iprocess-infrastructure/keys.tf
+++ b/groups/iprocess-infrastructure/keys.tf
@@ -1,4 +1,4 @@
 resource "aws_key_pair" "iprocess_app_keypair" {
-  key_name   = var.application
+  key_name   = "${var.application}-${var.environment}"
   public_key = local.iprocess_app_ec2_data["public-key"]
 }

--- a/groups/iprocess-infrastructure/locals.tf
+++ b/groups/iprocess-infrastructure/locals.tf
@@ -1,0 +1,68 @@
+locals {
+
+  s3_releases              = data.vault_generic_secret.s3_releases.data
+  iprocess_app_ec2_data    = data.vault_generic_secret.iprocess_app_ec2_data.data
+  iprocess_app_config_data = data.vault_generic_secret.iprocess_app_config_data.data
+
+  internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
+
+  security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data
+  kms_keys_data          = data.vault_generic_secret.kms_keys.data
+  logs_kms_key_id        = local.kms_keys_data["logs"]
+  ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
+  sns_kms_key_id         = local.kms_keys_data["sns"]
+
+  security_s3_data            = data.vault_generic_secret.security_s3_buckets.data
+  session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]
+
+  cloudwatch_instance_logs = {
+    for log, map in var.cloudwatch_logs :
+    log => merge(map, {
+      "log_group_name" = "${var.application}-${var.environment}-${log}"
+      }
+    )
+  }
+
+  # Extract the log group names for easier iteration
+  log_groups = compact([for log, map in local.cloudwatch_instance_logs : lookup(map, "log_group_name", "")])
+
+  default_tags = {
+    Terraform       = "true"
+    Application     = upper(var.application)
+    ApplicationType = upper(var.application_type)
+    Environment     = var.environment
+    Region          = var.aws_region
+    Account         = var.aws_account
+  }
+
+  iprocess_app_deployment_ansible_inputs = {
+    HOSTNAME             = format("%s-%s", var.application, var.environment)
+    DOMAIN               = local.internal_fqdn
+    APP_TCP_PORT         = local.iprocess_app_config_data["app_tcp_port"]
+    EAI_DB_PASS          = local.iprocess_app_config_data["eai_db_password"]
+    EAI_DB_SCHEMAOWNER   = local.iprocess_app_config_data["eai_db_schemaowner"]
+    EAI_DB_USER          = local.iprocess_app_config_data["eai_db_user"]
+    ORACLE_SID_VALUE     = local.iprocess_app_config_data["oracle_std_sid"]
+    DB_ADDRESS           = local.iprocess_app_config_data["db_address"]
+    DB_PORT              = local.iprocess_app_config_data["db_port"]
+    SWPRO_PASSWORD       = local.iprocess_app_config_data["swpro_password"]
+    region               = var.aws_region
+    cw_log_files         = local.cloudwatch_instance_logs
+    cw_agent_user        = "root"
+    cw_namespace         = var.cloudwatch_namespace
+    cw_asg_level_metrics = "true"
+    s3_bucket_configs    = local.s3_releases["config_bucket_name"]
+  }
+
+  iprocess_tnsnames_inputs = {
+    db_address     = local.iprocess_app_config_data["db_address"]
+    db_port        = local.iprocess_app_config_data["db_port"]
+    oracle_std_sid = local.iprocess_app_config_data["oracle_std_sid"]
+    oracle_taf_sid = local.iprocess_app_config_data["oracle_taf_sid"]
+    service_name   = local.iprocess_app_config_data["service_name"]
+  }
+
+  iprocess_staff_dat_inputs = {
+    staff_dat = local.iprocess_app_config_data["staff_dat"]
+  }
+}

--- a/groups/iprocess-infrastructure/locals.tf
+++ b/groups/iprocess-infrastructure/locals.tf
@@ -52,6 +52,7 @@ locals {
     cw_namespace         = var.cloudwatch_namespace
     cw_asg_level_metrics = "true"
     s3_bucket_configs    = local.s3_releases["config_bucket_name"]
+    crontab_filename     = "dev-crontab.txt"
   }
 
   iprocess_tnsnames_inputs = {

--- a/groups/iprocess-infrastructure/main.tf
+++ b/groups/iprocess-infrastructure/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 0.13.0, < 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 0.3, < 4.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 2.0.0"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.vault_username}"
+    parameters = {
+      password = var.vault_password
+    }
+  }
+}

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/development/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/development/vars
@@ -1,0 +1,66 @@
+# Account details
+aws_profile = "heritage-development-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-development"
+
+# Account shorthand
+account = "hdev"
+region  = "euw2"
+
+# Application details
+application = "iprocess-app"
+environment = "development"
+
+# ASG settings
+asg_count = 1
+instance_size = "z1d.3xlarge"
+enable_instance_refresh = true
+
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 7
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 7
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 7
+  }
+
+  "sw_warn.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }
+
+  "sw_error.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }
+
+  "ch_support_alert.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }  
+}

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/development/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/development/vars
@@ -13,7 +13,7 @@ environment = "development"
 
 # ASG settings
 asg_count = 1
-instance_size = "z1d.3xlarge"
+instance_size = "r5.large"
 enable_instance_refresh = true
 
 cloudwatch_logs = {

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training1/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training1/vars
@@ -13,7 +13,7 @@ environment = "training1"
 
 # ASG settings
 asg_count = 1
-instance_size = "z1d.3xlarge"
+instance_size = "r5.large"
 enable_instance_refresh = true
 
 cloudwatch_logs = {

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training1/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training1/vars
@@ -1,0 +1,66 @@
+# Account details
+aws_profile = "heritage-development-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-development"
+
+# Account shorthand
+account = "hdev"
+region  = "euw2"
+
+# Application details
+application = "iprocess-app"
+environment = "training1"
+
+# ASG settings
+asg_count = 1
+instance_size = "z1d.3xlarge"
+enable_instance_refresh = true
+
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 7
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 7
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 7
+  }
+
+  "sw_warn.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }
+
+  "sw_error.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }
+
+  "ch_support_alert.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }
+}

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training2/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training2/vars
@@ -1,0 +1,66 @@
+# Account details
+aws_profile = "heritage-development-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-development"
+
+# Account shorthand
+account = "hdev"
+region  = "euw2"
+
+# Application details
+application = "iprocess-app"
+environment = "training2"
+
+# ASG settings
+asg_count = 1
+instance_size = "z1d.3xlarge"
+enable_instance_refresh = true
+
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 7
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 7
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 7
+  }
+
+  "sw_warn.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }
+
+  "sw_error.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }
+
+  "ch_support_alert.log" = {
+    file_path = "/app/iProcess/11_8/logs"
+    log_group_retention = 7
+  }
+}

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training2/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training2/vars
@@ -13,7 +13,7 @@ environment = "training2"
 
 # ASG settings
 asg_count = 1
-instance_size = "z1d.3xlarge"
+instance_size = "r5.large"
 enable_instance_refresh = true
 
 cloudwatch_logs = {

--- a/groups/iprocess-infrastructure/sns.tf
+++ b/groups/iprocess-infrastructure/sns.tf
@@ -1,0 +1,35 @@
+module "cloudwatch_sns_email" {
+  count = var.enable_sns_topic ? 1 : 0
+
+  source  = "terraform-aws-modules/sns/aws"
+  version = "3.3.0"
+
+  name              = "${var.application}-${var.environment}-cloudwatch-emails"
+  display_name      = "${var.application}-${var.environment}-cloudwatch-alarms-for-emails"
+  kms_master_key_id = local.sns_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-CSI-Support"
+    )
+  )
+}
+
+module "cloudwatch_sns_ooh" {
+  count = var.enable_sns_topic ? 1 : 0
+
+  source  = "terraform-aws-modules/sns/aws"
+  version = "3.3.0"
+
+  name              = "${var.application}-${var.environment}-cloudwatch-ooh-only"
+  display_name      = "${var.application}-${var.environment}-cloudwatch-alarms-for-ooh"
+  kms_master_key_id = local.sns_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-CSI-Support"
+    )
+  )
+}

--- a/groups/iprocess-infrastructure/templates/user_data.tpl
+++ b/groups/iprocess-infrastructure/templates/user_data.tpl
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Redirect the user-data output to the console logs
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+#Use provided inputs to create final tnsnames.ora file
+cat <<EOF >>tnsnames.json
+${IPROCESS_TNS_INPUTS}
+EOF
+/usr/local/bin/j2 -f json /home/swenvp1/tnsnames.j2 tnsnames.json > /app/oracle/product/19c/network/admin/tnsnames.ora
+
+#Use provided inputs to create final staff.dat file
+cat <<'EOF' >>staff_dat.json
+${IPROCESS_STAFF_DAT_INPUTS}
+EOF
+/usr/local/bin/j2 -f json /home/swenvp1/staff_dat.j2 staff_dat.json > /app/iProcess/11_8/staff.dat
+
+#Run Ansible playbook for app deployment using provided inputs
+cat <<EOF >deployment.json
+${IPROCESS_APP_INPUTS}
+EOF
+/usr/local/bin/ansible-playbook /root/deployment.yml -e "@deployment.json"
+
+#Run DNS Update script with inputs
+FQDN=`cat deployment.json | jq -r '"\(.HOSTNAME).\(.DOMAIN)"'`
+sh /root/updatedns.sh ${R53_ZONEID} $FQDN

--- a/groups/iprocess-infrastructure/variables.tf
+++ b/groups/iprocess-infrastructure/variables.tf
@@ -1,0 +1,138 @@
+# ------------------------------------------------------------------------------
+# Vault Variables
+# ------------------------------------------------------------------------------
+variable "vault_username" {
+  type        = string
+  description = "Username for connecting to Vault - usually supplied through TF_VARS"
+}
+
+variable "vault_password" {
+  type        = string
+  description = "Password for connecting to Vault - usually supplied through TF_VARS"
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables
+# ------------------------------------------------------------------------------
+variable "aws_region" {
+  type        = string
+  description = "The AWS region in which resources will be administered"
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "The AWS profile to use"
+}
+
+variable "aws_account" {
+  type        = string
+  description = "The name of the AWS Account in which resources will be administered"
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables - Shorthand
+# ------------------------------------------------------------------------------
+
+variable "account" {
+  type        = string
+  description = "Short version of the name of the AWS Account in which resources will be administered"
+}
+
+variable "region" {
+  type        = string
+  description = "Short version of the name of the AWS region in which resources will be administered"
+}
+
+# ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+
+variable "application" {
+  type        = string
+  description = "The component name of the application"
+}
+
+variable "environment" {
+  type        = string
+  description = "The name of the environment"
+}
+
+variable "application_type" {
+  type        = string
+  default     = "chips"
+  description = "The parent name of the application"
+}
+
+# ------------------------------------------------------------------------------
+# ASG Variables
+# ------------------------------------------------------------------------------
+
+variable "instance_size" {
+  type        = string
+  description = "The size of the ec2 instances to build"
+}
+
+variable "asg_min_size" {
+  type        = number
+  default     = 1
+  description = "The min size of the ASG - always 1"
+}
+
+variable "asg_max_size" {
+  type        = number
+  default     = 1
+  description = "The max size of the ASG - always 1"
+}
+
+variable "asg_desired_capacity" {
+  type        = number
+  default     = 1
+  description = "The desired capacity of ASG - always 1"
+}
+
+variable "asg_count" {
+  type        = number
+  description = "The number of ASGs - typically 1 for dev and 2 for staging/live"
+}
+
+variable "ami_name" {
+  type        = string
+  default     = "iprocess-app-*"
+  description = "Name of the AMI to use in the Auto Scaling configuration"
+}
+
+variable "instance_root_volume_size" {
+  type        = number
+  default     = 100
+  description = "Size of root volume attached to instances"
+}
+
+variable "enable_instance_refresh" {
+  type        = bool
+  default     = false
+  description = "Enable or disable instance refresh when the ASG is updated"
+}
+
+variable "default_log_group_retention_in_days" {
+  type        = number
+  default     = 14
+  description = "Total days to retain logs in CloudWatch log group if not specified for specific logs"
+}
+
+variable "cloudwatch_logs" {
+  type        = map(any)
+  description = "Map of log file information; used to create log groups, IAM permissions and passed to the application to configure remote logging"
+  default     = {}
+}
+
+variable "cloudwatch_namespace" {
+  type        = string
+  default     = "CHIPS/STFWARE"
+  description = "A custom namespace to define for CloudWatch custom metrics such as memory and disk"
+}
+
+variable "enable_sns_topic" {
+  type        = bool
+  description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
+  default     = false
+}

--- a/groups/weblogic-infrastructure/alb.tf
+++ b/groups/weblogic-infrastructure/alb.tf
@@ -1,0 +1,86 @@
+module "internal_alb_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.3"
+
+  name        = "sgr-${var.application}-internal-alb-001"
+  description = "Security group for the ${var.application} servers"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_prefix_list_ids  = [data.aws_ec2_managed_prefix_list.administration.id]
+  ingress_rules       = ["http-80-tcp"]
+  egress_rules        = ["all-all"]
+}
+
+resource "aws_security_group_rule" "http_to_chips" {
+  description       = "HTTP from application, chs and test subnets"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  type              = "ingress"
+  cidr_blocks       = concat(local.chs_cidrs, local.application_subnet_cidrs, local.test_cidrs)
+  security_group_id = module.internal_alb_security_group.security_group_id
+}
+
+module "internal_alb" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 6.5"
+
+  name                       = "alb-${var.application}-int-01"
+  vpc_id                     = data.aws_vpc.vpc.id
+  internal                   = true
+  load_balancer_type         = "application"
+  enable_deletion_protection = false
+  idle_timeout               = 180
+
+  security_groups = [module.internal_alb_security_group.security_group_id]
+  subnets         = data.aws_subnet_ids.application.ids
+
+  http_tcp_listeners = [
+    {
+      port               = 80
+      protocol           = "HTTP"
+      target_group_index = 0
+    }
+  ]
+
+  http_tcp_listener_rules = [ 
+    for env in var.environments : {
+      http_tcp_listener_index = 0
+      priority                = env.number
+
+      actions = [
+        {
+          type               = "forward"
+          target_group_index = (env.number)-1
+          weight             = 100
+        }
+      ]
+      conditions = [{ host_headers = [format("%s-%s.*", var.application_type, env.name)] }]
+    }
+  ]
+
+  target_groups = [
+    for env in var.environments : {
+      name                 = format("tg-%s-%s", var.application, env.name)
+      backend_protocol     = "HTTP"
+      backend_port         = "2${env.number}00"
+      target_type          = "instance"
+      deregistration_delay = 60
+      health_check = {
+        enabled             = true
+        interval            = 30
+        path                = var.application_health_check_path
+        port                = "2${env.number}00"
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        timeout             = 6
+        protocol            = "HTTP"
+        matcher             = "200-399"
+      }
+
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    }
+  ]
+}

--- a/groups/weblogic-infrastructure/alb.tf
+++ b/groups/weblogic-infrastructure/alb.tf
@@ -39,19 +39,24 @@ module "internal_alb" {
     {
       port               = 80
       protocol           = "HTTP"
-      target_group_index = 0
+
+      action_type  = "fixed-response"
+      fixed_response = {
+        status_code  = "503"
+        content_type = "text/plain"
+      }
     }
   ]
 
   http_tcp_listener_rules = [ 
-    for env in var.environments : {
+    for index, env in var.environments : {
       http_tcp_listener_index = 0
       priority                = env.number
 
       actions = [
         {
           type               = "forward"
-          target_group_index = (env.number)-1
+          target_group_index = index
           weight             = 100
         }
       ]

--- a/groups/weblogic-infrastructure/asg.tf
+++ b/groups/weblogic-infrastructure/asg.tf
@@ -1,0 +1,131 @@
+# ------------------------------------------------------------------------------
+# CHIPS Security Group and rules
+# ------------------------------------------------------------------------------
+module "asg_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.3"
+
+  name        = "sgr-${var.application}-asg-001"
+  description = "Security group for the ${var.application} asg"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_rules       = ["ssh-tcp"]
+  ingress_prefix_list_ids  = [data.aws_ec2_managed_prefix_list.administration.id]
+
+  egress_rules = ["all-all"]
+}
+
+resource "aws_security_group_rule" "ssh_from_chips_control" {
+  description       = "SSH from chips-control"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  type              = "ingress"
+  source_security_group_id = data.aws_security_group.chips_control.id
+  security_group_id = module.asg_security_group.security_group_id
+}
+
+resource "aws_security_group_rule" "http_tux_to_chips" {
+  description       = "HTTP and tux from admin ips"
+  from_port         = 20100
+  to_port           = 22075
+  protocol          = "tcp"
+  type              = "ingress"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.administration.id]
+  security_group_id = module.asg_security_group.security_group_id
+}
+
+# ASG Module
+module "asg" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/autoscaling-with-launch-template?ref=tags/1.0.184"
+
+  count = var.asg_count
+
+  name = format("%s%s", var.application, count.index)
+
+  # Launch template configuration
+  lt_name       = format("%s%s-launchtemplate", var.application, count.index)
+  image_id      = data.aws_ami.ami.id
+  instance_type = var.instance_size
+  core_count    = 2
+  security_groups = [
+    module.asg_security_group.security_group_id
+  ]
+  root_block_device = [
+    {
+      volume_size = var.instance_root_volume_size
+      volume_type = "gp2"
+      encrypted   = true
+      iops        = 0
+    }
+  ]
+
+  # Auto scaling group
+  asg_name                       = format("%s%s-asg", var.application, count.index)
+  vpc_zone_identifier            = data.aws_subnet_ids.application.ids
+  health_check_type              = "EC2"
+  min_size                       = var.asg_min_size
+  max_size                       = var.asg_max_size
+  desired_capacity               = var.asg_desired_capacity
+  health_check_grace_period      = 300
+  wait_for_capacity_timeout      = 0
+  force_delete                   = true
+  enable_instance_refresh        = var.enable_instance_refresh
+  refresh_min_healthy_percentage = 50
+  refresh_triggers               = ["launch_configuration"]
+  key_name                       = aws_key_pair.keypair.key_name
+  termination_policies           = ["OldestLaunchConfiguration"]
+  
+  iam_instance_profile = module.instance_profile.aws_iam_instance_profile.name
+  user_data_base64     = data.template_cloudinit_config.userdata_config.rendered
+
+  tags_as_map = merge(
+    local.default_tags,
+    {
+      app-instance-name = format("%s%s", var.application, count.index)
+      config-base-path  = format("s3://%s/%s-configs", var.config_bucket_name, var.application)
+    }
+  )
+}
+
+resource "aws_cloudwatch_log_group" "log_groups" {
+  for_each = local.cloudwatch_logs
+
+  name              = each.value["log_group_name"]
+  retention_in_days = lookup(each.value, "log_group_retention", var.default_log_group_retention_in_days)
+  kms_key_id        = lookup(each.value, "kms_key_id", local.logs_kms_key_id)
+}
+
+#--------------------------------------------
+# ASG CloudWatch Alarms
+#--------------------------------------------
+module "asg_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/asg-cloudwatch-alarms?ref=tags/1.0.116"
+
+  count = var.asg_count
+
+  autoscaling_group_name = module.asg[count.index].this_autoscaling_group_name
+  prefix                 = "${var.aws_account}-${var.application}-${count.index}-asg-alarms"
+
+  in_service_evaluation_periods      = "1"
+  in_service_statistic_period        = "60"
+  expected_instances_in_service      = 1
+  in_pending_evaluation_periods      = "3"
+  in_pending_statistic_period        = "120"
+  in_standby_evaluation_periods      = "3"
+  in_standby_statistic_period        = "120"
+  in_terminating_evaluation_periods  = "3"
+  in_terminating_statistic_period    = "120"
+  total_instances_evaluation_periods = "1"
+  total_instances_statistic_period   = "120"
+  total_instances_in_service         = 1
+
+  actions_alarm = var.enable_sns_topic ? [module.cloudwatch_sns_email[0].sns_topic_arn, module.cloudwatch_sns_ooh[0].sns_topic_arn] : []
+  actions_ok    = var.enable_sns_topic ? [module.cloudwatch_sns_email[0].sns_topic_arn, module.cloudwatch_sns_ooh[0].sns_topic_arn] : []
+
+
+  depends_on = [
+    module.cloudwatch_sns_email,
+    module.asg
+  ]
+}

--- a/groups/weblogic-infrastructure/data.tf
+++ b/groups/weblogic-infrastructure/data.tf
@@ -1,0 +1,98 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "vpc" {
+  tags = {
+    Name = "vpc-${var.aws_account}"
+  }
+}
+
+data "aws_subnet_ids" "application" {
+  vpc_id = data.aws_vpc.vpc.id
+  filter {
+    name   = "tag:Name"
+    values = ["sub-application-*"]
+  }
+}
+
+data "aws_route53_zone" "private_zone" {
+  name         = local.internal_fqdn
+  private_zone = true
+}
+
+data "aws_kms_key" "sns_key" {
+  key_id = "alias/${var.account}/${var.region}/sns"
+}
+
+data "vault_generic_secret" "account_ids" {
+  path = "aws-accounts/account-ids"
+}
+
+data "aws_ec2_managed_prefix_list" "administration" {
+  name = "administration-cidr-ranges"
+}
+
+data "aws_security_group" "chips_control" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-control-asg-001-*"]
+  }
+}
+
+data "vault_generic_secret" "ec2_data" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/ec2"
+}
+
+data "vault_generic_secret" "kms_keys" {
+  path = "aws-accounts/${var.aws_account}/kms"
+}
+
+data "vault_generic_secret" "security_kms_keys" {
+  path = "aws-accounts/security/kms"
+}
+
+data "vault_generic_secret" "security_s3_buckets" {
+  path = "aws-accounts/security/s3"
+}
+
+data "vault_generic_secret" "nfs_mounts" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
+}
+
+data "aws_ami" "ami" {
+  owners      = [data.vault_generic_secret.account_ids.data["development"]]
+  most_recent = var.ami_name == "docker-ami-*" ? true : false
+
+  filter {
+    name = "name"
+    values = [
+      var.ami_name,
+    ]
+  }
+
+  filter {
+    name = "state"
+    values = [
+      "available",
+    ]
+  }
+}
+
+data "template_file" "userdata" {
+  template = file("${path.module}/templates/user_data.tpl")
+  vars = {
+    ANSIBLE_INPUTS             = jsonencode(local.userdata_ansible_inputs)
+    DNS_DOMAIN                 = local.internal_fqdn
+    DNS_ZONE_ID                = data.aws_route53_zone.private_zone.zone_id
+    HERITAGE_ENVIRONMENT       = title(var.environment)
+  }
+}
+
+data "template_cloudinit_config" "userdata_config" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = data.template_file.userdata.rendered
+  }
+}

--- a/groups/weblogic-infrastructure/data.tf
+++ b/groups/weblogic-infrastructure/data.tf
@@ -14,6 +14,11 @@ data "aws_subnet_ids" "application" {
   }
 }
 
+data "aws_subnet" "application" {
+  for_each = data.aws_subnet_ids.application.ids
+  id       = each.value
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true
@@ -29,6 +34,14 @@ data "vault_generic_secret" "account_ids" {
 
 data "aws_ec2_managed_prefix_list" "administration" {
   name = "administration-cidr-ranges"
+}
+
+data "vault_generic_secret" "chs_cidrs" {
+  path = "/aws-accounts/network/${var.aws_account}/chs/application-subnets"
+}
+
+data "vault_generic_secret" "test_cidrs" {
+  path = "aws-accounts/network/shared-services/test_cidr_ranges"
 }
 
 data "aws_security_group" "chips_control" {

--- a/groups/weblogic-infrastructure/iam.tf
+++ b/groups/weblogic-infrastructure/iam.tf
@@ -1,0 +1,78 @@
+module "instance_profile" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.59"
+
+  name       = format("%s-profile", var.application)
+  enable_SSM = true
+
+  s3_buckets_write = [local.session_manager_bucket_name]
+
+  kms_key_refs = [
+    "alias/${var.account}/${var.region}/ebs",
+    local.ssm_kms_key_id
+  ]
+
+  cw_log_group_arns = length(local.log_groups) > 0 ? [format(
+    "arn:aws:logs:%s:%s:log-group:%s-*:*",
+    var.aws_region,
+    data.aws_caller_identity.current.account_id,
+    var.application
+  )] : null
+
+  custom_statements = [
+    {
+      sid    = "AllowAccessToConfigBucket",
+      effect = "Allow",
+      resources = [
+        "arn:aws:s3:::${var.config_bucket_name}/*",
+        "arn:aws:s3:::${var.config_bucket_name}"
+      ],
+      actions = [
+        "s3:Get*",
+        "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowReadOnlyAccessToECR",
+      effect    = "Allow",
+      resources = ["*"],
+      actions = [
+        "ecr:GetAuthorizationToken",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability"
+      ]
+    },
+    {
+      sid       = "AllowReadOnlyDescribeAccessToEC2",
+      effect    = "Allow",
+      resources = ["*"],
+      actions = [
+        "ec2:Describe*"
+      ]
+    },
+    {
+      sid       = "AllowWriteToRoute53",
+      effect    = "Allow",
+      resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.private_zone.zone_id}"],
+      actions = [
+        "route53:ChangeResourceRecordSets"
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/chips/*"],
+      actions = [
+        "ssm:GetParameter*"
+      ]
+    },
+    {
+      sid       = "CloudwatchMetrics"
+      effect    = "Allow"
+      resources = ["*"]
+      actions = [
+        "cloudwatch:PutMetricData"
+      ]
+    }
+  ]
+}

--- a/groups/weblogic-infrastructure/keys.tf
+++ b/groups/weblogic-infrastructure/keys.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "keypair" {
+  key_name   = var.application
+  public_key = local.ec2_data["public-key"]
+}

--- a/groups/weblogic-infrastructure/locals.tf
+++ b/groups/weblogic-infrastructure/locals.tf
@@ -2,6 +2,10 @@ locals {
 
   ec2_data                 = data.vault_generic_secret.ec2_data.data
 
+  chs_cidrs                = values(data.vault_generic_secret.chs_cidrs.data)
+  application_subnet_cidrs = [for s in data.aws_subnet.application : s.cidr_block]
+  test_cidrs               = jsondecode(data.vault_generic_secret.test_cidrs.data["cidrs"])
+
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data

--- a/groups/weblogic-infrastructure/locals.tf
+++ b/groups/weblogic-infrastructure/locals.tf
@@ -1,0 +1,46 @@
+locals {
+
+  ec2_data                 = data.vault_generic_secret.ec2_data.data
+
+  internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
+
+  security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data
+  kms_keys_data          = data.vault_generic_secret.kms_keys.data
+  logs_kms_key_id        = local.kms_keys_data["logs"]
+  ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
+  sns_kms_key_id         = local.kms_keys_data["sns"]
+
+  security_s3_data            = data.vault_generic_secret.security_s3_buckets.data
+  session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]
+
+  nfs_mounts = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
+
+  #For each log map passed, add an extra kv for the log group name and append the NFS directory into the filepath where required
+  log_directory_prefix = format("%s/%s", var.nfs_mount_destination_parent_dir, lookup(local.nfs_mounts["application_root"], "local_mount_point", ""))
+  cloudwatch_logs = {
+    for log, map in var.cloudwatch_logs :
+    log => merge(map, {
+      "log_group_name" = "${var.application}-${log}",
+      "file_path"      = replace(map["file_path"], "NFSPATH", "${local.log_directory_prefix}/APPINSTANCENAME")
+      }
+    )
+  }
+  # Extract the log group names for easier iteration
+  log_groups = compact([for log, map in local.cloudwatch_logs : lookup(map, "log_group_name", "")])
+
+  default_tags = {
+    Terraform       = "true"
+    Application     = upper(var.application)
+    ApplicationType = upper(var.application_type)
+    Region          = var.aws_region
+    Account         = var.aws_account
+  }
+
+  userdata_ansible_inputs = {
+    mounts_parent_dir          = var.nfs_mount_destination_parent_dir
+    mounts                     = local.nfs_mounts
+    install_watcher_service    = false
+    cw_log_files               = local.cloudwatch_logs
+    cw_agent_user              = "root"
+  }
+}

--- a/groups/weblogic-infrastructure/main.tf
+++ b/groups/weblogic-infrastructure/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 0.13.0, < 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 0.3, < 4.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 2.0.0"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.vault_username}"
+    parameters = {
+      password = var.vault_password
+    }
+  }
+}

--- a/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -54,11 +54,11 @@ cloudwatch_logs = {
 }
 
 # List of dev/test/training environments
-# Add an entry here if you need a friendly URL or cloudwatch access to the Weblogic log
+# Add an entry to the end of the list, if you need a friendly URL or cloudwatch access to the Weblogic log
 # The number must match the ENV_NUMBER env var in the S3 properties file and be unique.
 environments = [
   {
-    name = "blarney"
+    name = "csi"
     number = "01"
   },
   {
@@ -68,5 +68,9 @@ environments = [
   {
     name = "training2"
     number = "03"
+  },
+  {
+    name = "cidev"
+    number = "04"
   }
 ]

--- a/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -52,3 +52,21 @@ cloudwatch_logs = {
     log_group_retention = 7
   }
 }
+
+# List of dev/test/training environments
+# Add an entry here if you need a friendly URL or cloudwatch access to the Weblogic log
+# The number must match the ENV_NUMBER env var in the S3 properties file and be unique.
+environments = [
+  {
+    name = "blarney"
+    number = "01"
+  },
+  {
+    name = "training1"
+    number = "02"
+  },
+  {
+    name = "training2"
+    number = "03"
+  }
+]

--- a/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -1,0 +1,54 @@
+# Account details
+aws_profile = "heritage-development-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-development"
+
+# Account shorthand
+account = "hdev"
+region  = "euw2"
+
+# Application details
+application = "chips-devtest"
+environment = "development"
+
+# ASG settings
+asg_count = 1
+instance_size = "z1d.3xlarge"
+enable_instance_refresh = false
+
+# NFS Mounts
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 7
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 7
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 7
+  }
+}

--- a/groups/weblogic-infrastructure/route53.tf
+++ b/groups/weblogic-infrastructure/route53.tf
@@ -1,0 +1,13 @@
+resource "aws_route53_record" "app" {
+  for_each = {for env in var.environments: env.name => env}
+
+  zone_id = data.aws_route53_zone.private_zone.zone_id
+  name    = "${var.application_type}-${each.value.name}"
+  type    = "A"
+
+  alias {
+    name                   = module.internal_alb.lb_dns_name
+    zone_id                = module.internal_alb.lb_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/groups/weblogic-infrastructure/sns.tf
+++ b/groups/weblogic-infrastructure/sns.tf
@@ -1,0 +1,35 @@
+module "cloudwatch_sns_email" {
+  count = var.enable_sns_topic ? 1 : 0
+
+  source  = "terraform-aws-modules/sns/aws"
+  version = "3.3.0"
+
+  name              = "${var.application}-cloudwatch-emails"
+  display_name      = "${var.application}-cloudwatch-alarms-for-emails"
+  kms_master_key_id = local.sns_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-CSI-Support"
+    )
+  )
+}
+
+module "cloudwatch_sns_ooh" {
+  count = var.enable_sns_topic ? 1 : 0
+
+  source  = "terraform-aws-modules/sns/aws"
+  version = "3.3.0"
+
+  name              = "${var.application}-cloudwatch-ooh-only"
+  display_name      = "${var.application}-cloudwatch-alarms-for-ooh"
+  kms_master_key_id = local.sns_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-CSI-Support"
+    )
+  )
+}

--- a/groups/weblogic-infrastructure/templates/user_data.tpl
+++ b/groups/weblogic-infrastructure/templates/user_data.tpl
@@ -17,5 +17,5 @@ echo '${ANSIBLE_INPUTS}' | jq --arg APP_INSTANCE_NAME "$APP_INSTANCE_NAME"  'wal
 #Upsert a Route53 DNS record for this EC2 instance
 /usr/local/bin/update-dns.sh ${DNS_ZONE_ID} "$APP_INSTANCE_NAME.${DNS_DOMAIN}"
 
-#Run bootstrap script to download config from S3 and start Docker containers
-#su -l ec2-user bootstrap
+#Run multi-bootstrap script to download configs from S3 and start multiple Docker environments
+su -l ec2-user multi-bootstrap

--- a/groups/weblogic-infrastructure/templates/user_data.tpl
+++ b/groups/weblogic-infrastructure/templates/user_data.tpl
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Redirect the user-data output to the console logs
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+#Get application instance identifier from tags in AWS metadata service
+EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+AVAILABILITY_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+EC2_REGION=$${AVAILABILITY_ZONE::-1}
+APP_INSTANCE_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=$EC2_INSTANCE_ID" "Name=key,Values=app-instance-name"  --region $EC2_REGION | jq -r '.Tags[]//[]|select(.Key=="app-instance-name")|.Value' )
+
+#Template application identifier into deployment playbook inputs
+echo '${ANSIBLE_INPUTS}' | jq --arg APP_INSTANCE_NAME "$APP_INSTANCE_NAME"  'walk(if type == "object" and has("file_path") then .file_path |= sub("APPINSTANCENAME"; $APP_INSTANCE_NAME) else . end)' > /root/ansible_inputs.json
+
+#Run Ansible playbook for server setup using provided inputs
+/usr/local/bin/ansible-playbook /root/deployment.yml -e '@/root/ansible_inputs.json'
+
+#Upsert a Route53 DNS record for this EC2 instance
+/usr/local/bin/update-dns.sh ${DNS_ZONE_ID} "$APP_INSTANCE_NAME.${DNS_DOMAIN}"
+
+#Run bootstrap script to download config from S3 and start Docker containers
+#su -l ec2-user bootstrap

--- a/groups/weblogic-infrastructure/variables.tf
+++ b/groups/weblogic-infrastructure/variables.tf
@@ -1,0 +1,144 @@
+# ------------------------------------------------------------------------------
+# Vault Variables
+# ------------------------------------------------------------------------------
+variable "vault_username" {
+  type        = string
+  description = "Username for connecting to Vault - usually supplied through TF_VARS"
+}
+
+variable "vault_password" {
+  type        = string
+  description = "Password for connecting to Vault - usually supplied through TF_VARS"
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables
+# ------------------------------------------------------------------------------
+variable "aws_region" {
+  type        = string
+  description = "The AWS region in which resources will be administered"
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "The AWS profile to use"
+}
+
+variable "aws_account" {
+  type        = string
+  description = "The name of the AWS Account in which resources will be administered"
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables - Shorthand
+# ------------------------------------------------------------------------------
+
+variable "account" {
+  type        = string
+  description = "Short version of the name of the AWS Account in which resources will be administered"
+}
+
+variable "region" {
+  type        = string
+  description = "Short version of the name of the AWS region in which resources will be administered"
+}
+
+# ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+
+variable "application" {
+  type        = string
+  description = "The component name of the application"
+}
+
+variable "environment" {
+  type        = string
+  description = "The name of the environment"
+}
+
+variable "application_type" {
+  type        = string
+  default     = "chips"
+  description = "The parent name of the application"
+}
+
+# ------------------------------------------------------------------------------
+# ASG Variables
+# ------------------------------------------------------------------------------
+
+variable "instance_size" {
+  type        = string
+  description = "The size of the ec2 instances to build"
+}
+
+variable "asg_min_size" {
+  type        = number
+  default     = 1
+  description = "The min size of the ASG - always 1"
+}
+
+variable "asg_max_size" {
+  type        = number
+  default     = 1
+  description = "The max size of the ASG - always 1"
+}
+
+variable "asg_desired_capacity" {
+  type        = number
+  default     = 1
+  description = "The desired capacity of ASG - always 1"
+}
+
+variable "asg_count" {
+  type        = number
+  description = "The number of ASGs - typically 1 for dev and 2 for staging/live"
+}
+
+variable "ami_name" {
+  type        = string
+  default     = "docker-ami-*"
+  description = "Name of the AMI to use in the Auto Scaling configuration"
+}
+
+variable "instance_root_volume_size" {
+  type        = number
+  default     = 100
+  description = "Size of root volume attached to instances"
+}
+
+variable "enable_instance_refresh" {
+  type        = bool
+  default     = false
+  description = "Enable or disable instance refresh when the ASG is updated"
+}
+
+variable "nfs_mount_destination_parent_dir" {
+  type        = string
+  description = "The parent folder that all NFS shares should be mounted inside on the EC2 instance"
+  default     = "/mnt"
+}
+
+variable "default_log_group_retention_in_days" {
+  type        = number
+  default     = 14
+  description = "Total days to retain logs in CloudWatch log group if not specified for specific logs"
+}
+
+variable "cloudwatch_logs" {
+  type        = map(any)
+  description = "Map of log file information; used to create log groups, IAM permissions and passed to the application to configure remote logging"
+  default     = {}
+}
+
+variable "config_bucket_name" {
+  type        = string
+  description = "Bucket name the application will use to retrieve configuration files"
+  default     = "heritage-development.eu-west-2.configs.gov.uk"
+}
+
+variable "enable_sns_topic" {
+  type        = bool
+  description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
+  default     = false
+}

--- a/groups/weblogic-infrastructure/variables.tf
+++ b/groups/weblogic-infrastructure/variables.tf
@@ -142,3 +142,22 @@ variable "enable_sns_topic" {
   description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
   default     = false
 }
+
+# ------------------------------------------------------------------------------
+# ALB Variables
+# ------------------------------------------------------------------------------
+
+variable "application_health_check_path" {
+  type        = string
+  default     = "/chips/cff"
+  description = "Target group health check path for application"
+}
+
+# ------------------------------------------------------------------------------
+# Environments
+# ------------------------------------------------------------------------------
+variable "environments" {
+  type        = list(map(string))
+  description = "List of environments to configure log groups, listener rules and friendly DNS entries for"
+  default     = []
+}

--- a/groups/weblogic-infrastructure/version
+++ b/groups/weblogic-infrastructure/version
@@ -1,0 +1,1 @@
+weblogic-infrastructure-1.0


### PR DESCRIPTION
Adds three iProcess ASGs for the development (for developers), training1 & training2 environments.

The code relies on an ASG module, that has not yet been merged, so this PR needs to be merged after the following PR (and the module version in asg.tf may need updating if not 1.0.184)
https://github.com/companieshouse/terraform-modules/pull/194 - CM-1511 - Add module for an ASG with launch template

Resolves:
https://companieshouse.atlassian.net/browse/CM-1399