### PR TITLE
Include environment in Security Group name

### DIFF
--- a/groups/iprocess-infrastructure/asg.tf
+++ b/groups/iprocess-infrastructure/asg.tf
@@ -5,8 +5,8 @@ module "asg_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "~> 4.3"
 
-  name        = "sgr-${var.application}-asg-001"
-  description = "Security group for the ${var.application} asg"
+  name        = "sgr-${var.application}-${var.environment}-asg-001"
+  description = "Security group for the ${var.application} ${var.environment} asg"
   vpc_id      = data.aws_vpc.vpc.id
 
   ingress_rules       = ["ssh-tcp"]


### PR DESCRIPTION
Including the environment in the SG name allows specific iProcess app environments to be granted access to the corresponding environment RDS instances, rather than having any environment access any RDS instance.
