### PR TITLE
Correct the name of the config bucket

### DIFF
--- a/groups/weblogic-infrastructure/variables.tf
+++ b/groups/weblogic-infrastructure/variables.tf
@@ -129,7 +129,7 @@ variable "cloudwatch_logs" {
 variable "config_bucket_name" {
   type        = string
   description = "Bucket name the application will use to retrieve configuration files"
-  default     = "heritage-development.eu-west-2.configs.gov.uk"
+  default     = "heritage-development.eu-west-2.configs.ch.gov.uk"
 }
 
 variable "enable_sns_topic" {


### PR DESCRIPTION
The config bucket name was incorrect as it was missing "ch" so that has been fixed in S3, and now the terraform needs to be updated to reflect the new location.

