### PR TITLE
Add HTTPS listener to support SSL access to dev environments

### DIFF
--- a/groups/weblogic-infrastructure/data.tf
+++ b/groups/weblogic-infrastructure/data.tf
@@ -71,6 +71,11 @@ data "vault_generic_secret" "nfs_mounts" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
 }
 
+data "aws_acm_certificate" "acm_cert" {
+  domain = var.domain_name
+  most_recent = true
+}
+
 data "aws_ami" "ami" {
   owners      = [data.vault_generic_secret.account_ids.data["development"]]
   most_recent = var.ami_name == "docker-ami-*" ? true : false

--- a/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -71,5 +71,13 @@ environments = [
   {
     name = "cidev"
     number = "04"
+  },
+  {
+    name = "swadmin"
+    number = "05"
+  },
+  {
+    name = "ssopoc"
+    number = "06"
   }
 ]

--- a/groups/weblogic-infrastructure/variables.tf
+++ b/groups/weblogic-infrastructure/variables.tf
@@ -148,6 +148,12 @@ variable "application_health_check_path" {
   description = "Target group health check path for application"
 }
 
+variable "domain_name" {
+  type        = string
+  default     = "*.companieshouse.gov.uk"
+  description = "Domain Name for ACM Certificate"
+}
+
 # ------------------------------------------------------------------------------
 # Environments
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The SSO POC (ssopoc env) needs to be able to use HTTPS when accessing CHIPS, so we have added an HTTPS listener to all development environments.  

Note that if HTTPS is used, the var `DISABLE_PROXY_SSL` needs to be set to false in the chips.properties file for the environment in question, so that the Apache plugin tells Weblogic that SSL is being used.  


Partially resolves:
https://companieshouse.atlassian.net/browse/SUP-1129