### PR TITLE
Avoid embedding sensitive data in the user data script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform**

--- a/groups/iprocess-infrastructure/data.tf
+++ b/groups/iprocess-infrastructure/data.tf
@@ -91,10 +91,11 @@ data "template_file" "userdata" {
   template = file("${path.module}/templates/user_data.tpl")
 
   vars = {
-    R53_ZONEID                = data.aws_route53_zone.private_zone.zone_id
-    IPROCESS_APP_INPUTS       = jsonencode(local.iprocess_app_deployment_ansible_inputs)
-    IPROCESS_TNS_INPUTS       = jsonencode(local.iprocess_tnsnames_inputs)
-    IPROCESS_STAFF_DAT_INPUTS = jsonencode(local.iprocess_staff_dat_inputs)
+    REGION                         = var.aws_region
+    R53_ZONEID                     = data.aws_route53_zone.private_zone.zone_id
+    DEPLOYMENT_ANSIBLE_INPUTS_PATH = "${local.parameter_store_path_prefix}/deployment_ansible_inputs"
+    TNSNAMES_INPUTS_PATH           = "${local.parameter_store_path_prefix}/tnsnames_inputs"
+    STAFF_DAT_INPUTS_PATH          = "${local.parameter_store_path_prefix}/staff_dat_inputs"
   }
 }
 

--- a/groups/iprocess-infrastructure/iam.tf
+++ b/groups/iprocess-infrastructure/iam.tf
@@ -8,7 +8,8 @@ module "instance_profile" {
 
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
 
   cw_log_group_arns = length(local.log_groups) > 0 ? [format(
@@ -47,6 +48,14 @@ module "instance_profile" {
       resources = ["*"]
       actions = [
         "cloudwatch:PutMetricData"
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
       ]
     }
   ]

--- a/groups/iprocess-infrastructure/locals.tf
+++ b/groups/iprocess-infrastructure/locals.tf
@@ -8,6 +8,7 @@ locals {
 
   security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data
   kms_keys_data          = data.vault_generic_secret.kms_keys.data
+  account_ssm_key_arn    = local.kms_keys_data["ssm"]
   logs_kms_key_id        = local.kms_keys_data["logs"]
   ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
   sns_kms_key_id         = local.kms_keys_data["sns"]
@@ -65,5 +66,13 @@ locals {
 
   iprocess_staff_dat_inputs = {
     staff_dat = local.iprocess_app_config_data["staff_dat"]
+  }
+
+  parameter_store_path_prefix = "/${var.application}/${var.environment}"
+
+  parameter_store_secrets = {
+    deployment_ansible_inputs = jsonencode(local.iprocess_app_deployment_ansible_inputs)
+    tnsnames_inputs           = jsonencode(local.iprocess_tnsnames_inputs)
+    staff_dat_inputs          = jsonencode(local.iprocess_staff_dat_inputs)
   }
 }

--- a/groups/iprocess-infrastructure/parameter-store.tf
+++ b/groups/iprocess-infrastructure/parameter-store.tf
@@ -1,0 +1,13 @@
+resource "aws_ssm_parameter" "parameters" {
+  for_each = local.parameter_store_secrets
+
+  name   = "${local.parameter_store_path_prefix}/${each.key}"
+  type   = "SecureString"
+  value  = each.value
+  key_id = local.account_ssm_key_arn
+
+  tags = {
+    Environment = var.environment
+    Application = var.application
+  }
+}

--- a/groups/iprocess-infrastructure/templates/user_data.tpl
+++ b/groups/iprocess-infrastructure/templates/user_data.tpl
@@ -5,15 +5,15 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 GET_PARAM_COMMAND="aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
 
 #Use provided inputs to create final tnsnames.ora file
-$${GET_PARAM_COMMAND} '${TNSNAMES_INPUTS_PATH}' > tnsnames.json.test
+$${GET_PARAM_COMMAND} '${TNSNAMES_INPUTS_PATH}' > tnsnames.json
 /usr/local/bin/j2 -f json /home/swenvp1/tnsnames.j2 tnsnames.json > /app/oracle/product/19c/network/admin/tnsnames.ora
 
 #Use provided inputs to create final staff.dat file
-$${GET_PARAM_COMMAND} '${STAFF_DAT_INPUTS_PATH}' > staff_dat.json.test
+$${GET_PARAM_COMMAND} '${STAFF_DAT_INPUTS_PATH}' > staff_dat.json
 /usr/local/bin/j2 -f json /home/swenvp1/staff_dat.j2 staff_dat.json > /app/iProcess/11_8/staff.dat
 
 #Run Ansible playbook for app deployment using provided inputs
-$${GET_PARAM_COMMAND} '${DEPLOYMENT_ANSIBLE_INPUTS_PATH}' > deployment.json.test
+$${GET_PARAM_COMMAND} '${DEPLOYMENT_ANSIBLE_INPUTS_PATH}' > deployment.json
 /usr/local/bin/ansible-playbook /root/deployment.yml -e "@deployment.json"
 
 #Run DNS Update script with inputs

--- a/groups/iprocess-infrastructure/templates/user_data.tpl
+++ b/groups/iprocess-infrastructure/templates/user_data.tpl
@@ -2,22 +2,18 @@
 # Redirect the user-data output to the console logs
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+GET_PARAM_COMMAND="aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
+
 #Use provided inputs to create final tnsnames.ora file
-cat <<EOF >>tnsnames.json
-${IPROCESS_TNS_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${TNSNAMES_INPUTS_PATH}' > tnsnames.json.test
 /usr/local/bin/j2 -f json /home/swenvp1/tnsnames.j2 tnsnames.json > /app/oracle/product/19c/network/admin/tnsnames.ora
 
 #Use provided inputs to create final staff.dat file
-cat <<'EOF' >>staff_dat.json
-${IPROCESS_STAFF_DAT_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${STAFF_DAT_INPUTS_PATH}' > staff_dat.json.test
 /usr/local/bin/j2 -f json /home/swenvp1/staff_dat.j2 staff_dat.json > /app/iProcess/11_8/staff.dat
 
 #Run Ansible playbook for app deployment using provided inputs
-cat <<EOF >deployment.json
-${IPROCESS_APP_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${DEPLOYMENT_ANSIBLE_INPUTS_PATH}' > deployment.json.test
 /usr/local/bin/ansible-playbook /root/deployment.yml -e "@deployment.json"
 
 #Run DNS Update script with inputs


### PR DESCRIPTION
The dev/training iprocess-app (Tibco iProcess/Staffware) EC2 instances contain sensitive data within the user data on the ch-heritage-dev account.  This affects the following instances:

iprocess-app-development
iprocess-app-training1
iprocess-app-training2

This change is to avoid embedding the sensitive data in the user data script and instead use parameter store, and access the data from there when the script runs. 

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2675