### PR TITLE
Use encrypted ebs volumes, enforce IMDSv2 and use AMI default of gp3

### DIFF
--- a/groups/weblogic-infrastructure/templates/user_data.tpl
+++ b/groups/weblogic-infrastructure/templates/user_data.tpl
@@ -3,8 +3,8 @@
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 #Get application instance identifier from tags in AWS metadata service
-EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-AVAILABILITY_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+EC2_INSTANCE_ID=$( ec2-metadata -i | awk '{print $2}' )
+AVAILABILITY_ZONE=$( ec2-metadata -z | awk '{print $2}' )
 EC2_REGION=$${AVAILABILITY_ZONE::-1}
 APP_INSTANCE_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=$EC2_INSTANCE_ID" "Name=key,Values=app-instance-name"  --region $EC2_REGION | jq -r '.Tags[]//[]|select(.Key=="app-instance-name")|.Value' )
 

--- a/groups/weblogic-infrastructure/variables.tf
+++ b/groups/weblogic-infrastructure/variables.tf
@@ -102,6 +102,36 @@ variable "instance_root_volume_size" {
   description = "Size of root volume attached to instances"
 }
 
+variable "instance_root_volume_throughput" {
+  type        = number
+  default     = 125
+  description = "The EC2 instance swap volume throughput (MiB/s)"
+}
+
+variable "instance_root_volume_iops" {
+  type        = number
+  default     = 3000
+  description = "The EC2 instance swap volume IOPS"
+}
+
+variable "instance_root_volume_type" {
+  type        = string
+  default     = "gp3"
+  description = "The EC2 instance swap volume type"
+}
+
+variable "instance_swap_volume_size" {
+  type        = number
+  default     = 5
+  description = "Size of swap volume attached to instances"
+}
+
+variable "enforce_imdsv2" {
+  description = "Whether to enforce use of IMDSv2 by setting http_tokens to required on the aws_launch_configuration"
+  type        = bool
+  default     = true
+}
+
 variable "enable_instance_refresh" {
   type        = bool
   default     = false

--- a/groups/weblogic-infrastructure/variables.tf
+++ b/groups/weblogic-infrastructure/variables.tf
@@ -105,19 +105,19 @@ variable "instance_root_volume_size" {
 variable "instance_root_volume_throughput" {
   type        = number
   default     = 125
-  description = "The EC2 instance swap volume throughput (MiB/s)"
+  description = "The EC2 instance root volume throughput (MiB/s)"
 }
 
 variable "instance_root_volume_iops" {
   type        = number
   default     = 3000
-  description = "The EC2 instance swap volume IOPS"
+  description = "The EC2 instance root volume IOPS"
 }
 
 variable "instance_root_volume_type" {
   type        = string
   default     = "gp3"
-  description = "The EC2 instance swap volume type"
+  description = "The EC2 instance root volume type"
 }
 
 variable "instance_swap_volume_size" {


### PR DESCRIPTION
Updates the weblogic-infrastructure group to use encryption for swap volume, switch to gp3 and enforce IMDSv2.


Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2731