### PR TITLE
Use encrypted swap volume with gp3 and also enforce IMDSv2

### DIFF
--- a/groups/iprocess-infrastructure/asg.tf
+++ b/groups/iprocess-infrastructure/asg.tf
@@ -67,7 +67,7 @@ resource "aws_security_group_rule" "db_events_from_rds" {
 
 # ASG Module
 module "asg" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/autoscaling-with-launch-template?ref=tags/1.0.184"
+  source = "git@github.com:companieshouse/terraform-modules//aws/autoscaling-with-launch-template?ref=tags/1.0.248"
 
   count = var.asg_count
 
@@ -82,10 +82,17 @@ module "asg" {
   ]
   root_block_device = [
     {
+      device_name = "/dev/sda1"
       volume_size = var.instance_root_volume_size
-      volume_type = "gp2"
+      volume_type = var.instance_root_volume_type
       encrypted   = true
-      iops        = 0
+    }
+  ]
+  block_device_mappings = [
+    {
+      device_name = "/dev/xvds"
+      volume_size = var.instance_swap_volume_size
+      encrypted   = true
     }
   ]
 
@@ -102,6 +109,7 @@ module "asg" {
   enable_instance_refresh        = var.enable_instance_refresh
   refresh_min_healthy_percentage = 50
   key_name                       = aws_key_pair.iprocess_app_keypair.key_name
+  enforce_imdsv2                 = var.enforce_imdsv2
   
   iam_instance_profile = module.instance_profile.aws_iam_instance_profile.name
   user_data_base64     = data.template_cloudinit_config.userdata_config.rendered

--- a/groups/iprocess-infrastructure/variables.tf
+++ b/groups/iprocess-infrastructure/variables.tf
@@ -103,7 +103,7 @@ variable "ami_name" {
 
 variable "instance_root_volume_size" {
   type        = number
-  default     = 40
+  default     = 100
   description = "Size of root volume attached to instances"
 }
 

--- a/groups/iprocess-infrastructure/variables.tf
+++ b/groups/iprocess-infrastructure/variables.tf
@@ -103,8 +103,26 @@ variable "ami_name" {
 
 variable "instance_root_volume_size" {
   type        = number
-  default     = 100
+  default     = 40
   description = "Size of root volume attached to instances"
+}
+
+variable "instance_root_volume_type" {
+  type        = string
+  default     = "gp3"
+  description = "The EC2 instance root volume type"
+}
+
+variable "instance_swap_volume_size" {
+  type        = number
+  default     = 5
+  description = "Size of swap volume attached to instances"
+}
+
+variable "enforce_imdsv2" {
+  description = "Whether to enforce use of IMDSv2 by setting http_tokens to required on the aws_launch_configuration"
+  type        = bool
+  default     = true
 }
 
 variable "enable_instance_refresh" {


### PR DESCRIPTION
Updates the iprocess-infrastructure group to use encryption for swap volume, switch to gp3 and enforce IMDSv2.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2731
