### PR TITLE
Add managed CIS scanning policy to instance role

### DIFF
--- a/groups/iprocess-infrastructure/iam.tf
+++ b/groups/iprocess-infrastructure/iam.tf
@@ -60,3 +60,8 @@ module "instance_profile" {
     }
   ]
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.instance_profile.aws_iam_role.name
+}

--- a/groups/iprocess-infrastructure/locals.tf
+++ b/groups/iprocess-infrastructure/locals.tf
@@ -34,6 +34,8 @@ locals {
     Environment     = var.environment
     Region          = var.aws_region
     Account         = var.aws_account
+    Repository      = "chips-devtest-terraform"
+    Service         = "CHIPS"
   }
 
   iprocess_app_deployment_ansible_inputs = {

--- a/groups/weblogic-infrastructure/iam.tf
+++ b/groups/weblogic-infrastructure/iam.tf
@@ -76,3 +76,8 @@ module "instance_profile" {
     }
   ]
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.instance_profile.aws_iam_role.name
+}

--- a/groups/weblogic-infrastructure/locals.tf
+++ b/groups/weblogic-infrastructure/locals.tf
@@ -51,6 +51,8 @@ locals {
     ApplicationType = upper(var.application_type)
     Region          = var.aws_region
     Account         = var.aws_account
+    Repository      = "chips-devtest-terraform"
+    Service         = "CHIPS"
   }
 
   userdata_ansible_inputs = {


### PR DESCRIPTION
Add managed policy to allow CIS scanning by Inspector

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2793
