### PR TITLE
Add accounts-poc environment

### DIFF
--- a/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -83,5 +83,9 @@ environments = [
   {
     name = "devops1"
     number = "07"
+  },
+  {
+    name = "accounts-poc"
+    number = "08"
   }
 ]


### PR DESCRIPTION
Adds a new temporary environment for accounts api filing integration testing, as env #08, accessed by http://chips-accounts-poc.development.heritage.aws.internal/chips/cff

The docs have been updated at https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4134109415/Cloud+CHIPS+e2e+test+training+environments