### PR TITLE
Allow access to dev/training iProcess SPO ports by source sg name patterns

### DIFF
--- a/groups/iprocess-infrastructure/asg.tf
+++ b/groups/iprocess-infrastructure/asg.tf
@@ -45,13 +45,15 @@ resource "aws_security_group_rule" "spo_from_onprem_weblogic" {
   security_group_id = module.asg_security_group.security_group_id
 }
 
-resource "aws_security_group_rule" "spo_from_cloud_weblogic" {
-  description              = "Oracle DB inbound port range"
+resource "aws_security_group_rule" "spo_source_sg_access" {
+  for_each = tomap(local.spo_access_source_groups)
+
+  description              = "Access to SPO ports from ${each.key}"
   from_port                = 30511
   to_port                  = 30514
   protocol                 = "tcp"
   type                     = "ingress"
-  source_security_group_id = data.aws_security_group.chips_devtest_app.id
+  source_security_group_id = each.value
   security_group_id        = module.asg_security_group.security_group_id
 }
 

--- a/groups/iprocess-infrastructure/data.tf
+++ b/groups/iprocess-infrastructure/data.tf
@@ -14,11 +14,17 @@ data "aws_subnet_ids" "application" {
   }
 }
 
-data "aws_security_group" "chips_devtest_app" {
+data "aws_security_groups" "spo_access_group_ids" {
+  for_each = toset(var.spo_access_sg_patterns)
   filter {
     name   = "group-name"
-    values = ["sgr-chips-devtest-asg-001-*"]
+    values = [each.key]
   }
+}
+
+data "aws_security_group" "spo_access_groups" {
+  for_each = toset(local.spo_access_source_sg_ids)
+  id       = each.key
 }
 
 data "aws_security_group" "iprocess_rds" {

--- a/groups/iprocess-infrastructure/locals.tf
+++ b/groups/iprocess-infrastructure/locals.tf
@@ -16,6 +16,9 @@ locals {
   security_s3_data            = data.vault_generic_secret.security_s3_buckets.data
   session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]
 
+  spo_access_source_sg_ids = flatten([for sg in data.aws_security_groups.spo_access_group_ids : sg.ids])
+  spo_access_source_groups = {for group in data.aws_security_group.spo_access_groups : group.tags.Name => group.id}
+
   cloudwatch_instance_logs = {
     for log, map in var.cloudwatch_logs :
     log => merge(map, {

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/development/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/development/vars
@@ -16,6 +16,10 @@ asg_count = 1
 instance_size = "r5.large"
 enable_instance_refresh = true
 
+spo_access_sg_patterns = [
+  "sgr-chips-*-asg-001-*"
+]
+
 cloudwatch_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training1/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training1/vars
@@ -16,6 +16,10 @@ asg_count = 1
 instance_size = "r5.large"
 enable_instance_refresh = true
 
+spo_access_sg_patterns = [
+  "sgr-chips-devtest-asg-001-*"
+]
+
 cloudwatch_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training2/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/training2/vars
@@ -16,6 +16,10 @@ asg_count = 1
 instance_size = "r5.large"
 enable_instance_refresh = true
 
+spo_access_sg_patterns = [
+  "sgr-chips-devtest-asg-001-*"
+]
+
 cloudwatch_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/iprocess-infrastructure/variables.tf
+++ b/groups/iprocess-infrastructure/variables.tf
@@ -139,8 +139,8 @@ variable "default_log_group_retention_in_days" {
 
 variable "cloudwatch_logs" {
   type        = map(any)
-  description = "Map of log file information; used to create log groups, IAM permissions and passed to the application to configure remote logging"
   default     = {}
+  description = "Map of log file information; used to create log groups, IAM permissions and passed to the application to configure remote logging"
 }
 
 variable "cloudwatch_namespace" {
@@ -151,6 +151,12 @@ variable "cloudwatch_namespace" {
 
 variable "enable_sns_topic" {
   type        = bool
-  description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
   default     = false
+  description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
+}
+
+variable "spo_access_sg_patterns" {
+  type        = list(string)
+  default     = []
+  description = "List of source security group name patterns that will have access to the SPO ports"
 }


### PR DESCRIPTION
Allows access based on source security group name patterns to staffware/iprocess app instances (development/training1/training2) for E2E/training weblogic apps.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-53
