### PR TITLE
Add cmstest cloud CHIPS environment

### DIFF
--- a/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/austin/vars
+++ b/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/austin/vars
@@ -1,0 +1,1 @@
+e2e_name = "austin"

--- a/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/cmstest/vars
+++ b/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/cmstest/vars
@@ -1,0 +1,1 @@
+e2e_name = "cmstest"


### PR DESCRIPTION
Adds a new environment, `cmstest`, for use by the ECMS project

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-581