### PR TITLE
Reference 1.0.320 of chips-app module to bring in iBoss ingress rules

### DIFF
--- a/groups/multi-weblogic-infrastructure/main.tf
+++ b/groups/multi-weblogic-infrastructure/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-app" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=tags/1.0.292"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=tags/1.0.320"
 
   application                        = local.application_name
   application_type                   = var.application_type


### PR DESCRIPTION
Reference 1.0.320 of chips-app module to bring in updates to the ALB security group to add ingress from iBoss cidrs.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-606
