### PR TITLE
enable deletion protection on lb

### DIFF
--- a/groups/weblogic-infrastructure/alb.tf
+++ b/groups/weblogic-infrastructure/alb.tf
@@ -39,7 +39,7 @@ module "internal_alb" {
   vpc_id                     = data.aws_vpc.vpc.id
   internal                   = true
   load_balancer_type         = "application"
-  enable_deletion_protection = false
+  enable_deletion_protection = true
   idle_timeout               = 180
 
   security_groups = [module.internal_alb_security_group.security_group_id]


### PR DESCRIPTION
Enable deletion protection on alb-chips-devtest-int-01 lb:

Plan: 0 to add, 1 to change, 0 to destroy.

~ enable_deletion_protection       = false -> true

arn_suffix                       = "app/alb-chips-devtest-int-01/deb819e1647cc5e3"