### PR TITLE
Set asg_count to 2 for waldorf

### DIFF
--- a/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/waldorf/vars
+++ b/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/waldorf/vars
@@ -1,1 +1,2 @@
-e2e_name = "waldorf"
+e2e_name  = "waldorf"
+asg_count = 2


### PR DESCRIPTION
Increase the number of ASGs to 2 for waldorf to allow testing in a multi-cluster CHIPS environment

Resolves:
https://companieshouse.atlassian.net/browse/CHP-705