### PR TITLE
Staffware app ingress from CHIPS E2E clone instances

### DIFF
--- a/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/development/vars
+++ b/groups/iprocess-infrastructure/profiles/heritage-development-eu-west-2/development/vars
@@ -17,6 +17,7 @@ instance_size = "r5.large"
 enable_instance_refresh = true
 
 spo_access_sg_patterns = [
+  "development-chips-e2e-*",
   "sgr-chips-*-asg-001-*"
 ]
 


### PR DESCRIPTION
Updates the SG patterns to allow access from the CHIPS E2E clone instances.