### PR TITLE
Disable overnight shutdown on cmstest env

### DIFF
--- a/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/cmstest/vars
+++ b/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/cmstest/vars
@@ -1,1 +1,5 @@
 e2e_name = "cmstest"
+
+# Disable overnight shutdown
+shutdown_schedule = null
+startup_schedule = null


### PR DESCRIPTION
In order to run overnight processes, we need to keep the environment running.  Initial testing is using the cmstest env, so just disabling the shutdown there for now.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-708