### PR TITLE
Disable overnight shutdown and load cached docker images on startup

### DIFF
--- a/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/cmstest/vars
+++ b/groups/multi-weblogic-infrastructure/profiles/heritage-development-eu-west-2/cmstest/vars
@@ -1,5 +1,2 @@
 e2e_name = "cmstest"
 
-# Disable overnight shutdown
-shutdown_schedule = null
-startup_schedule = null

--- a/groups/multi-weblogic-infrastructure/variables.tf
+++ b/groups/multi-weblogic-infrastructure/variables.tf
@@ -142,13 +142,13 @@ variable "config_base_path_override" {
 variable "shutdown_schedule" {
   type        = string
   description = "Cron expression for the shutdown time - e.g. '00 20 * * 1-5' is 8pm Mon-Fri"
-  default     = "00 20 * * 1-5"
+  default     = null
 }
 
 variable "startup_schedule" {
   type        = string
   description = "Cron expression for the startup time - e.g. '00 06 * * 1-5' is 6am Mon-Fri"
-  default     = "05 07 * * 1-5"
+  default     = null
 }
 
 # ------------------------------------------------------------------------------
@@ -322,6 +322,7 @@ variable "bootstrap_commands" {
   type        = list(string)
   default     = [
     "su -l ec2-user weblogic-pre-bootstrap.sh",
+    "su -l ec2-user load-cached-images.sh",
     "su -l ec2-user bootstrap"
   ]
   description = "List of bootstrap commands to run during the instance startup"


### PR DESCRIPTION
Temporarily disable the overnight shutdown for all envs.  Run the load-cached-images.sh script on startup, to restore any locally cached images.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-708