### PR TITLE
Set alias of build for build container

### DIFF
--- a/groups/multi-weblogic-infrastructure/variables.tf
+++ b/groups/multi-weblogic-infrastructure/variables.tf
@@ -321,6 +321,7 @@ variable "enable_sns_topic" {
 variable "bootstrap_commands" {
   type        = list(string)
   default     = [
+    "su -l ec2-user set-container-alias.sh build build weblogic",
     "su -l ec2-user weblogic-pre-bootstrap.sh",
     "su -l ec2-user load-cached-images.sh",
     "su -l ec2-user bootstrap"


### PR DESCRIPTION
Call the set-container-alias.sh script to set an alias, so that users can enter the build container by just typing `build`, which is simpler than something like `docker exec -it -u weblogic cidev-build-1 bash`

Resolves:
https://companieshouse.atlassian.net/browse/CHP-741