### PR TITLE
Allow access to tuxedo ports from on-premise cidrs

### DIFF
--- a/groups/multi-weblogic-infrastructure/data.tf
+++ b/groups/multi-weblogic-infrastructure/data.tf
@@ -1,3 +1,7 @@
 data "vault_generic_secret" "nfs_mounts" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
 }
+
+data "aws_ec2_managed_prefix_list" "on_premise_cidr_ranges" {
+  name = "on-premise-cidr-ranges"
+}

--- a/groups/multi-weblogic-infrastructure/locals.tf
+++ b/groups/multi-weblogic-infrastructure/locals.tf
@@ -1,3 +1,9 @@
 locals {
-    application_name = "chips-${var.e2e_name}"
+  application_name = "chips-${var.e2e_name}"
+
+  on_premise_cidr_ranges = flatten([
+    for entry in data.aws_ec2_managed_prefix_list.on_premise_cidr_ranges.entries : [
+      entry.cidr
+    ]
+  ])
 }

--- a/groups/multi-weblogic-infrastructure/main.tf
+++ b/groups/multi-weblogic-infrastructure/main.tf
@@ -60,7 +60,7 @@ module "chips-app" {
       to_port     = 49078
       protocol    = "tcp"
       description = "Tuxedo ports"
-      cidr_blocks = join(",", [for s in module.chips-app.application_subnets : s.cidr_block])
+      cidr_blocks = join(",", concat([for s in module.chips-app.application_subnets : s.cidr_block], local.on_premise_cidr_ranges))
     },
     {
       from_port   = 21010


### PR DESCRIPTION
Provides ingress to ports 49075-49078 to allow the on-prem CHL environments to connect to CHIPS.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-739