### PR TITLE
Add log groups for main build logs

### DIFF
--- a/groups/multi-weblogic-infrastructure/variables.tf
+++ b/groups/multi-weblogic-infrastructure/variables.tf
@@ -308,6 +308,30 @@ variable "cloudwatch_logs" {
       file_name = "eai-eaidaemon-*.log"
       log_group_retention = 7
     }
+
+    "build-failure-log" = {
+      file_path = "NFSPATH/running-servers/buildlogs"
+      file_name = "build_failure.log"
+      log_group_retention = 7
+    }
+
+    "full-monty-build-log" = {
+      file_path = "NFSPATH/running-servers/buildlogs"
+      file_name = "full-monty-*.log"
+      log_group_retention = 7
+    }
+
+    "quick-build-deploy-log" = {
+      file_path = "NFSPATH/running-servers/buildlogs"
+      file_name = "quick-build-deploy-*.log"
+      log_group_retention = 7
+    }
+
+    "full-build-test-deploy-log" = {
+      file_path = "NFSPATH/running-servers/buildlogs"
+      file_name = "full-build-test-deploy-*.log"
+      log_group_retention = 7
+    }
   }
   description = "Map of log file information; used to create log groups, IAM permissions and passed to the application to configure remote logging"
 }


### PR DESCRIPTION
Adds log groups for the following logs, so they are sent to CloudWatch:

- build_failure.log
- full-monty-*.log
- quick-build-deploy-*.log
- full-build-test-deploy-*.log

Resolves:
https://companieshouse.atlassian.net/browse/CHP-802