### PR TITLE
Reduce instance size and remove migrated/decommissioned env config

### DIFF
--- a/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -12,7 +12,7 @@ application = "chips-devtest"
 
 # ASG settings
 asg_count = 1
-instance_size = "z1d.3xlarge"
+instance_size = "z1d.xlarge"
 enable_instance_refresh = false
 
 # NFS Mounts
@@ -61,32 +61,12 @@ environments = [
     number = "01"
   },
   {
-    name = "training1"
-    number = "02"
-  },
-  {
     name = "training2"
     number = "03"
   },
   {
-    name = "cidev"
-    number = "04"
-  },
-  {
-    name = "swadmin"
-    number = "05"
-  },
-  {
     name = "ssopoc"
     number = "06"
-  },
-  {
-    name = "devops1"
-    number = "07"
-  },
-  {
-    name = "accounts-poc"
-    number = "08"
   },
   {
     name = "cidevtux"


### PR DESCRIPTION
Platform have asked for the devtest0 instance on heritage-dev to be reduced in size, and this PR reduces the size from z1d.3xlarge to z1d.xlarge.

There are a number of environments that have been migrated from the devtest0 instance that have clashing DNS entries, so some additional work is required when applying this change, in order to recreate the DNS entries for devop1, training1 & cidev after apply.  That will be done by running plan/apply for each of those envs on the pipeline https://ci-platform.companieshouse.gov.uk/teams/team-infrastructure/pipelines/chips-e2e-weblogic
As the DNS entries will be removed for a brief period, this change needs to be applied out of hours.

The removal of the envs from the vars file will prevent that being an issue in future for those particular environments.

