### PR TITLE
Allow training2 http access to fes-control on devtest

### DIFF
--- a/groups/weblogic-infrastructure/asg.tf
+++ b/groups/weblogic-infrastructure/asg.tf
@@ -55,6 +55,16 @@ resource "aws_security_group_rule" "http_from_chips_control" {
   security_group_id        = module.asg_security_group.security_group_id
 }
 
+resource "aws_security_group_rule" "http_from_training2" {
+  description              = "HTTP from chips-training2"
+  from_port                = 20100
+  to_port                  = 22075
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = data.aws_security_group.chips_training2.id
+  security_group_id        = module.asg_security_group.security_group_id
+}
+
 resource "aws_security_group_rule" "http_from_ois_tuxedo" {
   description              = "HTTP from ois tuxedo"
   from_port                = 20100

--- a/groups/weblogic-infrastructure/data.tf
+++ b/groups/weblogic-infrastructure/data.tf
@@ -51,6 +51,13 @@ data "aws_security_group" "chips_control" {
   }
 }
 
+data "aws_security_group" "chips_training2" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-training2-asg-001-*"]
+  }
+}
+
 data "vault_generic_secret" "ec2_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/ec2"
 }

--- a/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/weblogic-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -61,10 +61,6 @@ environments = [
     number = "01"
   },
   {
-    name = "training2"
-    number = "03"
-  },
-  {
     name = "ssopoc"
     number = "06"
   },


### PR DESCRIPTION
Adds an ingress rule to allow the separate new training2 environment http access to the fes-control instance running on devtest0.  This is needed as a temporary measure until we can provision a new separate fes-control instance and decommission the old devtest0 server.